### PR TITLE
Fail noisily if WAB can't find the needed css link

### DIFF
--- a/config/_WABMixin.js
+++ b/config/_WABMixin.js
@@ -55,6 +55,11 @@ define([
 
         startup: function () {
             this.inherited(arguments);
+
+            if (!document.getElementById('theme_cmv_style_common')) {
+                throw new Error('WAB Widgets require the cmv app.css file to have an id of "theme_cmv_style_common"');
+            }
+            
             if (this.mapDeferred) {
                 this.mapDeferred.then(lang.hitch(this, '_configureWAB'));
             }

--- a/config/_WABMixin.js
+++ b/config/_WABMixin.js
@@ -56,8 +56,9 @@ define([
         startup: function () {
             this.inherited(arguments);
 
-            if (!document.getElementById('theme_cmv_style_common')) {
-                throw new Error('WAB Widgets require the cmv app.css file to have an id of "theme_cmv_style_common"');
+            var themeLinkIid = 'theme_' + wabConfig.theme.name + '_style_common';
+            if (!document.getElementById(themeLinkIid)) {
+                throw new Error('WAB Widgets require the cmv app.css file to have an id of "' + themeLinkIid + '"');
             }
             
             if (this.mapDeferred) {


### PR DESCRIPTION
Throws an error if _WABMixin can't find a css link with id='theme_cmv_style_common'
Without this css link WAB widgets with their own css files will never load.